### PR TITLE
Use sync.Pool to reduce allocations in bsc

### DIFF
--- a/sha3/sha3.go
+++ b/sha3/sha3.go
@@ -79,25 +79,11 @@ func (d *state) clone() *state {
 	return &ret
 }
 
-var uintPool = &sync.Pool{
-	New: func() interface{} {
-		i := [25]uint64{}
-		return i
-	},
-}
-
-var storagePool = &sync.Pool{
-	New: func() interface{} {
-		s := storageBuf{}
-		return s
-	},
-}
-
 var statePool = &sync.Pool{
 	New: func() interface{} {
 		s := state{
-			a:       uintPool.Get().([25]uint64),
-			storage: storagePool.Get().(storageBuf),
+			a:       [25]uint64{},
+			storage: storageBuf{},
 		}
 		return s
 	},
@@ -245,8 +231,6 @@ func (d *state) Sum(in []byte) []byte {
 	hash := make([]byte, dup.outputLen)
 	dup.Read(hash)
 
-	uintPool.Put(dup.a)
-	storagePool.Put(dup.storage)
 	statePool.Put(*dup)
 
 	return append(in, hash...)

--- a/sha3/sha3.go
+++ b/sha3/sha3.go
@@ -79,18 +79,14 @@ func (d *state) clone() *state {
 	return &ret
 }
 
-var statePool = &sync.Pool{
+var statePool = sync.Pool{
 	New: func() interface{} {
-		s := state{
-			a:       [25]uint64{},
-			storage: storageBuf{},
-		}
-		return s
+		return new(state)
 	},
 }
 
 func (d *state) cloneWithSyncPool() *state {
-	ret := statePool.Get().(state)
+	ret := statePool.Get().(*state)
 
 	ret.rate = d.rate
 	ret.outputLen = d.outputLen
@@ -113,7 +109,7 @@ func (d *state) cloneWithSyncPool() *state {
 		ret.buf = ret.storage.asBytes()[d.rate-cap(d.buf) : d.rate]
 	}
 
-	return &ret
+	return ret
 }
 
 // permute applies the KeccakF-1600 permutation. It handles
@@ -231,7 +227,7 @@ func (d *state) Sum(in []byte) []byte {
 	hash := make([]byte, dup.outputLen)
 	dup.Read(hash)
 
-	statePool.Put(*dup)
+	statePool.Put(dup)
 
 	return append(in, hash...)
 }


### PR DESCRIPTION
In BSC, `Sum` function is heavily used, and this pr tries to reduce the allocation in `Sum` function (actually the `clone` function).

# Result
* Before
```
go tool pprof allocs_8_20220412-184550.pprof
File: bsc_perf
Build ID: bd72b03ad79dc40d7f53c866751e69c9e08dd62a
Type: alloc_space
Time: Apr 12, 2022 at 6:45pm (UTC)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top10
Showing nodes accounting for 266.41GB, 55.32% of 481.60GB total
Dropped 1621 nodes (cum <= 2.41GB)
Showing top 10 nodes out of 240
      flat  flat%   sum%        cum   cum%
  116.76GB 24.24% 24.24%   116.76GB 24.24%  golang.org/x/crypto/sha3.(*state).clone (inline)
   40.28GB  8.36% 32.61%    40.28GB  8.36%  github.com/ethereum/go-ethereum/trie.(*fullNode).copy
   22.36GB  4.64% 37.25%    22.37GB  4.65%  github.com/syndtr/goleveldb/leveldb/util.(*BufferPool).Get
   16.75GB  3.48% 40.73%   133.51GB 27.72%  golang.org/x/crypto/sha3.(*state).Sum
   14.32GB  2.97% 43.70%    14.37GB  2.98%  github.com/ethereum/go-ethereum/eth/fetcher.(*TxFetcher).scheduleFetches.func1
   12.65GB  2.63% 46.33%    21.99GB  4.57%  github.com/ethereum/go-ethereum/eth.(*handler).BroadcastTransactions
   12.45GB  2.59% 48.91%    12.48GB  2.59%  github.com/syndtr/goleveldb/leveldb/table.(*Reader).newBlockIter
   11.02GB  2.29% 51.20%    11.02GB  2.29%  github.com/ethereum/go-ethereum/core/vm.(*Memory).Resize
   10.98GB  2.28% 53.48%    10.98GB  2.28%  github.com/ethereum/go-ethereum/eth/protocols/eth.(*Peer).announceTransactions
    8.84GB  1.84% 55.32%     9.19GB  1.91%  github.com/ethereum/go-ethereum/trie.expandNode
```

* After

```
go tool pprof allocs_8_20220412-184545.pprof
File: bsc_perf
Build ID: e76a638fc55f889c1119a52ddc5677bcbf07b0ad
Type: alloc_space
Time: Apr 12, 2022 at 6:45pm (UTC)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top 10
Showing nodes accounting for 144.37GB, 41.81% of 345.26GB total
Dropped 1565 nodes (cum <= 1.73GB)
Showing top 10 nodes out of 278
      flat  flat%   sum%        cum   cum%
   39.67GB 11.49% 11.49%    39.67GB 11.49%  github.com/ethereum/go-ethereum/trie.(*fullNode).copy (inline)
   18.55GB  5.37% 16.86%    18.56GB  5.38%  github.com/syndtr/goleveldb/leveldb/util.(*BufferPool).Get
   14.12GB  4.09% 20.95%    14.12GB  4.09%  golang.org/x/crypto/sha3.(*state).Sum
      13GB  3.77% 24.71%    13.03GB  3.77%  github.com/syndtr/goleveldb/leveldb/table.(*Reader).newBlockIter
   11.88GB  3.44% 28.16%    21.02GB  6.09%  github.com/ethereum/go-ethereum/eth.(*handler).BroadcastTransactions
   10.89GB  3.15% 31.31%    10.89GB  3.15%  github.com/ethereum/go-ethereum/core/vm.(*Memory).Resize
   10.62GB  3.08% 34.39%    10.63GB  3.08%  github.com/ethereum/go-ethereum/eth/protocols/eth.(*Peer).announceTransactions
    9.50GB  2.75% 37.14%     9.53GB  2.76%  github.com/ethereum/go-ethereum/eth/fetcher.(*TxFetcher).scheduleFetches.func1
    8.24GB  2.39% 39.53%     8.56GB  2.48%  github.com/ethereum/go-ethereum/trie.expandNode
    7.90GB  2.29% 41.81%    23.32GB  6.75%  github.com/ethereum/go-ethereum/trie.(*committer).commitChildren
```

We can see the No.1 allocation is disappeared.